### PR TITLE
Change social links orientation to be vertical

### DIFF
--- a/src/components/SocialLinks.module.scss
+++ b/src/components/SocialLinks.module.scss
@@ -9,9 +9,10 @@
     align-items: center;
     margin: 15px 0;
 
-    div {
+    button {
         margin: 5px 15px;
         cursor: pointer;
+        display: flex;
     }
 }
 
@@ -25,7 +26,7 @@
         top: 0;
     }
 
-    .social-links div {
+    .social-links button {
         display: inline-grid;
         position: relative;
     }


### PR DESCRIPTION
After gatsby update the social links turned up horizontal orientation. This PR adjusts the CSS to show vertically.
Closes #4 