### PR TITLE
Multiple authors

### DIFF
--- a/content/2017-01-01-bold-mage.md
+++ b/content/2017-01-01-bold-mage.md
@@ -2,6 +2,7 @@
 date: 2017-01-01
 title: "Bold Mage"
 cover: "https://unsplash.it/400/300/?random?BoldMage"
+author: johnsmith
 categories: 
     - Tech
     - React

--- a/content/2017-01-01-bold-mage.md
+++ b/content/2017-01-01-bold-mage.md
@@ -2,7 +2,7 @@
 date: 2017-01-01
 title: "Bold Mage"
 cover: "https://unsplash.it/400/300/?random?BoldMage"
-author: johnsmith
+authorSlug: johnsmith
 categories: 
     - Tech
     - React

--- a/content/2017-02-01-the-fallen-time.md
+++ b/content/2017-02-01-the-fallen-time.md
@@ -2,7 +2,7 @@
 date: 2017-02-01
 title: "The Fallen Time"
 cover: "https://unsplash.it/400/300/?random?TheFallenTime"
-author: maryjane
+authorSlug: maryjane
 categories: 
     - Tech
     - React

--- a/content/2017-02-01-the-fallen-time.md
+++ b/content/2017-02-01-the-fallen-time.md
@@ -2,6 +2,7 @@
 date: 2017-02-01
 title: "The Fallen Time"
 cover: "https://unsplash.it/400/300/?random?TheFallenTime"
+author: maryjane
 categories: 
     - Tech
     - React

--- a/data/Authors.js
+++ b/data/Authors.js
@@ -1,0 +1,20 @@
+const authors = {
+  maryjane: {
+    name: 'Mary Jane',
+    twitter: 'gatsbyjs',
+    github: 'gatsbyjs',
+    avatar: 'https://i.ibb.co/WPz9CNk/avatar.jpg',
+    description:
+      "Yeah, I like animals better than people sometimes... Especially dogs. Dogs are the best. Every time you come home, they act like they haven't seen you in a year. And the good thing about dogs... is they got different dogs for different people.",
+  },
+  johnsmith: {
+    name: 'John Smith',
+    twitter: 'gatsbyjs',
+    github: 'gatsbyjs',
+    avatar: 'https://i.ibb.co/WPz9CNk/avatar.jpg',
+    description:
+      "Yeah, I like animals better than people sometimes... Especially dogs. Dogs are the best. Every time you come home, they act like they haven't seen you in a year. And the good thing about dogs... is they got different dogs for different people.",
+  },
+}
+
+module.exports = authors;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,9 +41,9 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     createNodeField({ node, name: "slug", value: slug });
 
     if (
-      Object.prototype.hasOwnProperty.call(node.frontmatter, "author")
+      Object.prototype.hasOwnProperty.call(node.frontmatter, "authorSlug")
     ) {
-      createNodeField({ node, name: "author", value: Authors[node.frontmatter.author] });
+      createNodeField({ node, name: "author", value: Authors[node.frontmatter.authorSlug] });
     }
   }
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,6 +2,7 @@ const path = require("path");
 const _ = require("lodash");
 const moment = require("moment");
 const siteConfig = require("./data/SiteConfig");
+const Authors = require("./data/Authors");
 
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions;
@@ -38,6 +39,12 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
       }
     }
     createNodeField({ node, name: "slug", value: slug });
+
+    if (
+      Object.prototype.hasOwnProperty.call(node.frontmatter, "author")
+    ) {
+      createNodeField({ node, name: "author", value: Authors[node.frontmatter.author] });
+    }
   }
 };
 

--- a/src/components/Bio.js
+++ b/src/components/Bio.js
@@ -2,19 +2,18 @@ import React from 'react'
 import { Follow } from 'react-twitter-widgets'
 import * as styles from './Bio.module.scss'
 
-const Bio = ({ config, expanded }) => (
+const Bio = ({ author, expanded }) => (
   <>
     <img
       className={styles.avatar}
-      src={config.userAvatar}
-      alt={config.userName}
+      src={author.avatar}
+      alt={author.name}
     />
     <span>
-      Written by <strong>{config.userName}</strong> who lives and works in San
-      Francisco building useful things.
+      Written by <strong>{author.name}</strong>.
       {` `}
       <Follow
-        username={config.userTwitter}
+        username={author.twitter}
         options={{ count: expanded ? true : 'none' }}
       />
     </span>

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -15,6 +15,7 @@ const PostTemplate = ({ data, pageContext }) => {
   const postNode = data.markdownRemark
   const post = postNode.frontmatter
   const date = postNode.fields.date
+  const author = postNode.fields.author;
   if (!post.id) {
     post.id = slug
   }
@@ -36,7 +37,9 @@ const PostTemplate = ({ data, pageContext }) => {
           <div dangerouslySetInnerHTML={{ __html: postNode.html }} />
 
           <hr />
-          <Bio config={config} />
+          {author &&
+            <Bio author={author} />
+          }
           <div className={styles.postMeta}>
             <SocialLinks postPath={slug} postNode={postNode} />
           </div>
@@ -79,6 +82,12 @@ export const pageQuery = graphql`
       fields {
         slug
         date(formatString: "MMMM DD, YYYY")
+        author {
+          name
+          avatar
+          twitter
+          description
+        }
       }
     }
   }


### PR DESCRIPTION
This PR enable multiple authors bio and closes #2 

## The concept
Inside the markdown post will have a field called `authorSlug` that correspond a index inside the new `data/Authors.js` file that has the bio entire information.

## The implementation
During the node creation the Gatsby (`gatsby-node`) will create a node field called `author` containing the author bio information (e.g name, avatar, etc...) extracted from `data/Authors.js` file that was indexed by author id.

## How to test
1. Run `npm run develop`
2. Access the post http://localhost:8000/the-fallen-time, the author must be `Mary Jane`
3. Access the post http://localhost:8000/bold-mage, the author must be `John Smith`
4. Access other post, the bio section must not be shown